### PR TITLE
Clear the locations table before running a new scan

### DIFF
--- a/src/gf-form-locator/classes/class-gravity-form-locator.php
+++ b/src/gf-form-locator/classes/class-gravity-form-locator.php
@@ -105,6 +105,12 @@ class Gravity_Form_Locator {
 	 */
 	public function scan() {
 
+		global $wpdb;
+		$gform_form_page_table = $wpdb->prefix . 'gform_form_page';
+		$wpdb->query(
+			$wpdb->prepare( 'TRUNCATE TABLE %s', $gform_form_page_table )
+		);
+
 		$args = array(
 			'post_type' => array( 'page', 'post' ),
 		);


### PR DESCRIPTION
This would be the easiest way to handle issues where form locations would appear to exist, even if they don't. For example, if a user ran the scan and a form existed on a post. If they removed the form from the post and scanned again, the location wouldn't be cleared out of the table.